### PR TITLE
HIVE-108160: Vivek: Fix: Duplicate API calls and incorrect payload on Awaiting Appointments tab

### DIFF
--- a/src/controllers/manage/appointmentsFilterController.js
+++ b/src/controllers/manage/appointmentsFilterController.js
@@ -26,19 +26,7 @@ angular.module('bahmni.appointments')
 
                 var params = {v: "custom:(display,person,uuid,retired,attributes:(attributeType:(display),value,voided))"};
 
-                $scope.$watch("selectedProviders", function (selectedProviders) {
-                    if (!_.isUndefined($scope.selectedSpecialities)) {
-                        $scope.applyFilter();
-                    }
-                });
-
-                $scope.$watch("selectedLocations", function (selectedLocations) {
-                    if (!_.isUndefined($scope.selectedSpecialities)) {
-                        $scope.applyFilter();
-                    }
-                });
-
-                $scope.$watch("selectedStatusList", function (selectedStatusList) {
+                $scope.$watchGroup(["selectedProviders", "selectedLocations", "selectedStatusList"], function () {
                     if (!_.isUndefined($scope.selectedSpecialities)) {
                         $scope.applyFilter();
                     }

--- a/src/controllers/manage/list/appointmentsListViewController.js
+++ b/src/controllers/manage/list/appointmentsListViewController.js
@@ -106,7 +106,7 @@ angular.module('bahmni.appointments')
                     .then((response) => updateAppointments(response));
                 }
                 else
-                return appointmentsService.search( prefilledPatient ? { patientUuid: prefilledPatient } : APPOINTMENT_STATUS_WAITLIST)
+                return appointmentsService.search( prefilledPatient ? { patientUuids: [prefilledPatient] } : APPOINTMENT_STATUS_WAITLIST)
                 .then((response) => updateAppointments(response))
                 .catch((error) => messagingService.showMessage('error', 'APPOINTMENT_SEARCH_TIME_ERROR'));
             };

--- a/test/controllers/manage/appointmentsFilterController.spec.js
+++ b/test/controllers/manage/appointmentsFilterController.spec.js
@@ -820,4 +820,16 @@ describe('AppointmentsFilterController', function () {
             status: "WaitList"
         });
     });
+
+    it("should call applyFilter only once when selectedProviders and selectedLocations both change in the same digest cycle", function() {
+        q.all.and.returnValue(specUtil.simplePromise([servicesWithTypes, providers, locations]));
+        createController();
+        spyOn(scope, 'applyFilter').and.callThrough();
+
+        scope.selectedProviders = [];
+        scope.selectedLocations = [];
+        scope.$digest();
+
+        expect(scope.applyFilter).toHaveBeenCalledTimes(1);
+    });
 });

--- a/test/controllers/manage/list/appointmentsListViewController.spec.js
+++ b/test/controllers/manage/list/appointmentsListViewController.spec.js
@@ -101,6 +101,18 @@ describe('AppointmentsListViewController', function () {
         expect(spinner.forPromise).not.toHaveBeenCalled();
     });
 
+    it('should call appointmentsService.search with patientUuids as array when patient is prefilled via query param', function () {
+        inject(function ($location) {
+            $location.search('patient', 'test-patient-uuid');
+        });
+        appointmentsService.search = jasmine.createSpy('search').and.returnValue(specUtil.simplePromise({data: []}));
+        $state.current = {tabName: 'awaitingappointments'};
+        $state.params = {doFetchAppointmentsData: true, filterParams: {}};
+        createController();
+        scope.getAppointmentsForDate(new Date());
+        expect(appointmentsService.search).toHaveBeenCalledWith({patientUuids: ['test-patient-uuid']});
+    });
+
     it('should not fetch appointments when doFetchAppointmentsData is set to false', function () {
         $state.params = {doFetchAppointmentsData: false};
         createController();


### PR DESCRIPTION
Problem

  Two separate bugs were identified in the Appointments module causing unnecessary/failing API calls to POST
  /openmrs/ws/rest/v1/appointment/search:

  1. Duplicate API calls on "Awaiting Appointments" tab load
  Clicking the "Awaiting Appointments" tab triggered two identical search requests with the same payload
  {"serviceUuids":[],"serviceTypeUuids":[],"providerUuids":[],"locationUuids":[],"statusList":["WaitList"],"withoutDates":true}.
  This slowed down page load.

  Root cause: AppointmentsFilterController had three separate $watch statements on selectedProviders, selectedLocations, and
  selectedStatusList. During initialization, the $q.all response set both selectedProviders and selectedLocations in the same
  $digest cycle — each watch independently fired applyFilter(), resulting in two API calls.

  2. Failing search call when opening patient link in a new tab
  Clicking a patient link (from "Awaiting Surgery Date" records with an appointment date) triggered two search calls — one failing,
  one working:
  - ❌ {"patientUuid": "..."} — singular string, backend returns no results
  - ✅ {"patientUuids": ["..."]} — array format, works correctly

  Root cause: setAppointments() in AppointmentsListViewController used patientUuid (singular) instead of patientUuids (array),
  inconsistent with every other call site in the codebase.

  ---
  Fix

  ┌───────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │  Commit   │                                                      Change                                                      │
  ├───────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 7cece176b │ Replaced three separate $watch calls with a single $watchGroup in AppointmentsFilterController. $watchGroup      │
  │           │ fires at most once per $digest cycle regardless of how many watched values changed.                              │
  ├───────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ bbbf5b48a │ Fixed patientUuid: prefilledPatient → patientUuids: [prefilledPatient] in setAppointments() to match the         │
  │           │ expected API payload schema.                                                                                     │
  └───────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

  Tests Added

  - Regression test asserting applyFilter() is called exactly once when selectedProviders and selectedLocations both change in the
  same digest cycle.
  - Regression test asserting appointmentsService.search is called with patientUuids as an array when a patient is prefilled via
  query param.