### PR TITLE
Bindu | HIVE - 111066 | fix hyperlink issue with provider data in appointment summary page

### DIFF
--- a/ui/react-components/components/GridSummary/GridSummary.jsx
+++ b/ui/react-components/components/GridSummary/GridSummary.jsx
@@ -106,7 +106,7 @@ const loadMessage = (message, gridName) => {
   </div>
 }
 const GridSummary = props => {
-  const { gridData=[], weekStartDate = moment().startOf("isoweek"), onClick, gridName, noAppointmentsMessage } = props;
+  const { gridData=[], weekStartDate = moment().startOf("isoweek"), onClick, gridName, noAppointmentsMessage, filterType } = props;
   let week = []
   const { fullSummary, isLoading } = React.useContext(AppContext)
   const intl = useIntl();
@@ -157,7 +157,7 @@ const GridSummary = props => {
                       weekDay.missedCount += a.missedCount;
                       return (
                           <td key={row.rowLabel+index+weekDay.date} className={classNames({[currentDateColumn]:currentDate})}>
-                            <a onClick={() => onClick(weekDay.date, a.uuid, gridName)}>{a.count}</a>
+                            <a onClick={() => onClick(weekDay.date, a.uuid, filterType || gridName)}>{a.count}</a>
                             <span className={missedCount}>
                           {a.missedCount > 0
                               ? " (" + a.missedCount + " missed)"

--- a/ui/react-components/containers/AppointmentSummaryContainer.jsx
+++ b/ui/react-components/containers/AppointmentSummaryContainer.jsx
@@ -82,14 +82,14 @@ class AppointmentSummaryContainer extends Component {
                     <DateOrWeekNavigator isWeek={true} weekStart={1} />
                     { fullSummary? (
                         <div>
-                            <GridSummary gridData={specialityData} weekStartDate={startDate} onClick={goToListView} gridName={specialitiesTitle} noAppointmentsMessage={noAppointmentsMessageSpecialities}/>
+                            <GridSummary gridData={specialityData} weekStartDate={startDate} onClick={goToListView} gridName={specialitiesTitle} filterType={'Specialities'} noAppointmentsMessage={noAppointmentsMessageSpecialities}/>
                             <hr/>
-                            <GridSummary gridData={providersData} weekStartDate={startDate} onClick={goToListView} gridName={providersTitle} noAppointmentsMessage={noAppointmentsMessageProviders}/>
+                            <GridSummary gridData={providersData} weekStartDate={startDate} onClick={goToListView} gridName={providersTitle} filterType={'Providers'} noAppointmentsMessage={noAppointmentsMessageProviders}/>
                             <hr/>
                             <GridSummary gridData={sortBy(data, row => row.rowLabel.toLowerCase())}
-                                         weekStartDate={startDate} onClick={goToListView} gridName={servicesTitle} noAppointmentsMessage={noAppointmentsMessageServices}/>
+                                         weekStartDate={startDate} onClick={goToListView} gridName={servicesTitle} filterType={'Services'} noAppointmentsMessage={noAppointmentsMessageServices}/>
                             <hr/>
-                            <GridSummary gridData={locationData} weekStartDate={startDate} onClick={goToListView} gridName={locationsTitle} noAppointmentsMessage={noAppointmentsMessageLocations}/>
+                            <GridSummary gridData={locationData} weekStartDate={startDate} onClick={goToListView} gridName={locationsTitle} filterType={'Locations'} noAppointmentsMessage={noAppointmentsMessageLocations}/>
                             <br/>
                         </div>) : (
                         <GridSummary gridData={ data } weekStartDate={startDate} onClick={goToListView}/>


### PR DESCRIPTION
https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=dBpjCkQThD6yP94GK

 **Issue:**  The GridSummary component used gridName (which holds a localized display title like "Providers Summary", "Specialities Summary") as the filter type when a user clicked a count hyperlink.   
  This was incorrect — the goToListView handler needs a consistent, language-agnostic filter type string (e.g., 'Providers') to properly filter the appointment list view. 
**Fix:**  The fix decouples the display label (gridName) from the filter key (filterType).                                                                                                                       